### PR TITLE
Add better Linux support.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 zig-cache
 zig-out
+tools/openocd/bring-your-own/*

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,15 +6,15 @@
     "configurations": [
         {
             "cwd": "${workspaceRoot}",
-            "executable": "zig-out/bin/adsr",
+            "executable": "zig-out/bin/single_tone",
             "name": "Debug with OpenOCD",
             "request": "launch",
             "type": "cortex-debug",
-            "servertype": "openocd",
-            "configFiles": [],
-            "searchDir": [],
+            "servertype": "external",
             "runToEntryPoint": "main.main",
-            "showDevDebugOutput": "none"
+            "showDevDebugOutput": "raw",
+            "preLaunchTask": "Build",
+            "gdbTarget": "localhost:3333",
         },
         {
             "debuggerPath": "arm-none-eabi-gdb",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,11 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "Build",
+            "type": "shell",
+            "command": "zig build",
+            "options": {"cwd": "${workspaceRoot}"}
+        }
+    ]
+}

--- a/README.adoc
+++ b/README.adoc
@@ -49,16 +49,27 @@ If this does not work for you for some reason, you can download zig from https:/
 
 At the time of writing, I've not been able to get the current release of OpenOCD (0.12.0) working correctly on MacOS, this was sourced using `brew`. Instead I have found success with https://github.com/raspberrypi/openocd[Raspberry Pi's fork of OpenOCD].
 
-If you run `windows` or `macos` I've committed binaries to this repository since they're easy to package. If you run `linux` though you'll have to build it on your own, and then add it to your `PATH`:
+If you run `windows` or `macos` I've committed binaries to this repository since they're easy to package. If you run `linux` though you'll have to build it on your own inside of "tools/openocd/bring-your-own". This folder and it's correct contents are created when the following commands are run from the root of this repository:
 
 [source]
 ----
-git clone https://github.com/raspberrypi/openocd
-cd openocd
+cd tools/openocd
+git clone https://github.com/raspberrypi/openocd bring-your-own
+cd bring-your-own
 ./bootstrap
-./configure --enable-picoprobe --prefix ~/.local # change the prefix/install location as you like
+./configure --enable-picoprobe --prefix $PWD/install
 make -j4 install
 ----
+
+==== Permissions on Linux
+By default, serial devices on Linux (The picobrobe being one of them) are not usable by non-root users. To enable access, you must add a udev rule in "/etc/udev/rules.d" to tell Linux that you want the permissions on the device to be writable by all users. This can be done by running the following command:
+
+[source]
+----
+echo 'ATTRS{product}=="*CMSIS-DAP*", MODE="660", TAG+="uaccess"' | sudo tee -a /etc/udev/rules.d/60-openocd-picoprobe.rules
+----
+
+The pico probe should work after re-plugging it into your computer.
 
 == Setting up VS Code for Zig and Embedded Development
 

--- a/build.zig
+++ b/build.zig
@@ -79,9 +79,8 @@ pub fn build(b: *Builder) void {
 
     // openocd
     const openocd_subdir = comptime std.fmt.comptimePrint("tools/openocd/{s}-{s}", .{ arch_str, os_str });
-    const openocd_scripts_dir = comptime std.fmt.comptimePrint("{s}/share/openocd/scripts", .{openocd_subdir});
     const openocd_exe = if (builtin.os.tag == .linux)
-        "openocd"
+        "tools/openocd/bring-your-own/install/bin/openocd"
     else
         comptime std.fmt.comptimePrint("{s}/bin/openocd{s}", .{
         openocd_subdir,
@@ -99,7 +98,7 @@ pub fn build(b: *Builder) void {
 
     // linux users need to build their own openocd
     if (builtin.os.tag == .linux) {
-        run_openocd.addArgs(&.{ "-s", openocd_scripts_dir });
+        run_openocd.addArgs(&.{ "-s", "tools/openocd/bring-your-own/install/share/openocd/scripts" });
     }
 
     const openocd = b.step("openocd", "run openocd for your debugger");


### PR DESCRIPTION
I wanted to compile this again but this time on Linux. I've added an optional "build-your-own" directory to tools/openocd which the zig file looks in if you're on Linux. Instructions are updated as well to get this directory set-up and address the permission issues.

I've also updated the VSCODE launch.json/tasks.json files to build the workshop and connect to the openOCD server run by "zig build openocd".